### PR TITLE
Exclude Python 3.8.4 from use under Windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ venv/
 .vscode/
 .eggs/
 /local
+.envrc

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,9 @@ This will start a server at `http://127.0.0.1:5000/
 Running tests
 -------------
 
-To run the skep test suite::
+To run the skep test suite, your currently active AWS credentials must have
+access to S3 APIs. You may need to add an `AWS_PROFILE` definition to your
+environment::
 
     $ AWS_PROFILE=beeware pytest
 

--- a/skep/platforms.py
+++ b/skep/platforms.py
@@ -31,6 +31,7 @@ def windows_support_url(version, host_arch, revision):
         # Remove them from consideration.
         known_bad = {
             '3.7': {7},
+            '3.8': {4},
         }.get(version, [])
 
         best_url = None


### PR DESCRIPTION
Python 3.8.4 includes a regression around the handling of `python38._pth`.  

See also https://bugs.python.org/issue41304 and beeware/briefcase#453.
