### PR TITLE
Lock the support revisions that are returned.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,9 @@
+** NOTE: This service was used by Briefcase v0.3.0 - v0.3.9. However, in Briefcase
+v0.3.10, templates locked their preferred support package. This service will be
+retained for support of legacy Briefcase versions, but the behavior is now "static",
+returning the support pacakges that were current as of the release of v0.3.10. Once
+traffic has dropped off, this service will be retired.**
+
 Skep
 ====
 

--- a/skep/platforms.py
+++ b/skep/platforms.py
@@ -1,4 +1,3 @@
-import requests
 
 
 def windows_support_url(version, host_arch, revision):

--- a/skep/platforms.py
+++ b/skep/platforms.py
@@ -18,105 +18,82 @@ def windows_support_url(version, host_arch, revision):
             version=version, micro=parts[0], revision=revision, host_arch=host_arch
         )
     else:
-        # We can shortcut the process by priming the minor versions
-        # that we already know exist.
-        micro = {
-            '3.5': 4,
-            '3.6': 8,
-            '3.7': 5,
-            '3.8': 2,
-        }.get(version, 0)
+        # Lock the most recent known versions as of the pre-release of Briefcase 0.3.10
+        try:
+            micro = {
+                '3.5': 4,
+                '3.6': 8,
+                '3.7': 9,
+                '3.8': 10,
+                '3.9': 13,
+                '3.10': 7,
+            }[version]
 
-        # There are micro versions that are known bad.
-        # Remove them from consideration.
-        known_bad = {
-            '3.7': {7},
-            '3.8': {4},
-        }.get(version, [])
-
-        best_url = None
-        while True:
-            candidate_url = url.format(
+            best_url = url.format(
                 version=version,
                 micro=micro,
                 revision=micro,
                 host_arch=host_arch,
             )
-
-            # If the micro version is in the list of known bad releases,
-            # remove it from consideration.
-            if micro in known_bad:
-                found_candidate = False
-            else:
-                response = requests.head(candidate_url)
-                if response.status_code == 200:
-                    found_candidate = True
-                elif response.status_code == 404:
-                    found_candidate = False
-                else:
-                    raise RuntimeError('Problem detecting Windows support package')
-
-            if found_candidate:
-                best_url = candidate_url
-            else:
-                # No base version; look for a post release.
-                candidate_url = url.format(
-                    version=version,
-                    micro=micro,
-                    revision=f'{micro}.post1',
-                    host_arch=host_arch,
-                )
-                response = requests.head(candidate_url)
-
-                if response.status_code == 200:
-                    best_url = candidate_url
-                elif response.status_code == 404:
-                    # No micro version candidate, and no post release of
-                    # micro version; we've hit the end of our search
-                    break
-                else:
-                    raise RuntimeError('Problem detecting Windows support package')
-
-            # Try the next micro version.
-            micro += 1
-
-    if best_url is None:
-        raise ValueError('Unsupported major.minor version')
+        except KeyError:
+            raise ValueError('Unsupported major.minor version')
 
     return best_url
 
 
 def support_url(s3, bucket, platform, version, host_arch, revision):
-    if host_arch is None:
-        prefix = f'python/{version}/{platform}/'
-    else:
-        prefix = f'python/{version}/{platform}/{host_arch}/'
+    try:
+        if host_arch is None:
+            prefix = f'python/{version}/{platform}'
 
-    # List all the objects in the bucket.
-    # Look for the highest build number.
-    top_build_number = 0
-    top_build = None
-    for page in s3.get_paginator('list_objects_v2').paginate(Bucket=bucket, Prefix=prefix):
-        for item in page.get('Contents', []):
-            # Filename is either foo.b1.zip or foo.b1.tar.gz
-            # Find the "b1" part of the name.
-            key_parts = item['Key'].split('.')
-            if key_parts[-1] == 'zip':
-                build_str = key_parts[-2]
+            if platform == "android":
+                best_revision = {
+                    '3.6': 3,
+                    '3.7': 9,
+                    '3.8': 5,
+                    '3.9': 3,
+                    '3.10': 2,
+                }[version]
+                if revision is None:
+                    revision = best_revision
+
+                top_build = f"{prefix}/Python-{version}-Android-support.b{revision}.zip"
+            elif platform in {"iOS", "macOS"}:
+                best_revision = {
+                    '3.5': 12,
+                    '3.6': 14,
+                    '3.7': 9,
+                    '3.8': 9,
+                    '3.9': 7,
+                    '3.10': 3,
+                }[version]
+                if revision is None:
+                    revision = best_revision
+
+                top_build = f"{prefix}/Python-{version}-{platform}-support.b{revision}.tar.gz"
             else:
-                build_str = key_parts[-3]
+                top_build = None
+        elif platform == "linux" and host_arch == "x86_64":
+            prefix = f'python/{version}/{platform}/{host_arch}'
 
-            build_number = int(build_str.lstrip('b'))
-            if revision:
-                if build_str == revision:
-                    top_build = item['Key']
-                    break
-            else:
-                if build_number > top_build_number:
-                    top_build_number = build_number
-                    top_build = item['Key']
+            best_revision = {
+                '3.5': 2,
+                '3.6': 4,
+                '3.7': 6,
+                '3.8': 6,
+                '3.9': 4,
+                '3.10': 3,
+            }[version]
+            if revision is None:
+                revision = best_revision
 
-    # If we didn't find at least one file, raise 404.
+            top_build = f"{prefix}/Python-{version}-linux-{host_arch}-support.b{revision}.tar.gz"
+        else:
+            top_build = None
+    except KeyError:
+        top_build = None
+
+    # If we didn't find a file, raise 404.
     if top_build is None:
         raise ValueError()
 

--- a/tests/platforms/test_support_url.py
+++ b/tests/platforms/test_support_url.py
@@ -2,7 +2,6 @@ from urllib.parse import urlparse, parse_qsl
 
 import boto3
 import pytest
-from botocore.stub import Stubber
 
 from skep.platforms import support_url
 
@@ -54,7 +53,6 @@ def test_valid_support_url(s3, platform, version, host_arch, revision, expected_
     assert 'Expires' in query
     assert 'AWSAccessKeyId' in query
     assert 'Signature' in query
-
 
 
 @pytest.mark.parametrize(
@@ -115,8 +113,8 @@ def test_valid_support_url(s3, platform, version, host_arch, revision, expected_
 
     ]
 )
-def test_valid_support_url(s3, platform, version, host_arch, revision):
-    "The support URLs in place at the time of the release of Briefcase v0.3.10 can be returned"
+def test_invalid_support_url(s3, platform, version, host_arch, revision):
+    "Bad support URL requests are rejected."
     # Retrieve the property, retrieving the support package URL.
     with pytest.raises(ValueError):
         support_url(

--- a/tests/platforms/test_support_url.py
+++ b/tests/platforms/test_support_url.py
@@ -13,348 +13,117 @@ def s3():
     return session.client('s3')
 
 
-def test_single_match(s3):
-    "If a single match exists, it is returned"
-    stub_s3 = Stubber(s3)
+@pytest.mark.parametrize(
+    "platform, version, host_arch, revision, expected_path",
+    [
+        ("linux", "3.8", "x86_64", None, "/python/3.8/linux/x86_64/Python-3.8-linux-x86_64-support.b6.tar.gz"),
+        ("linux", "3.10", "x86_64", None, "/python/3.10/linux/x86_64/Python-3.10-linux-x86_64-support.b3.tar.gz"),
+        ("linux", "3.8", "x86_64", "2", "/python/3.8/linux/x86_64/Python-3.8-linux-x86_64-support.b2.tar.gz"),
 
-    # Add the expected request/responses from S3
-    stub_s3.add_response(
-        method='list_objects_v2',
-        expected_params={
-            'Bucket': 'briefcase-support',
-            'Prefix': 'python/3.X/tester/'
-        },
-        service_response={
-            'Contents': [
-                {'Key': 'python/3.X/tester/Python-3.X-tester-support.b1.tar.gz'}
-            ],
-            'KeyCount': 1,
-        }
-    )
+        ("android", "3.8", None, None, "/python/3.8/android/Python-3.8-Android-support.b5.zip"),
+        ("android", "3.10", None, None, "/python/3.10/android/Python-3.10-Android-support.b2.zip"),
+        ("android", "3.8", None, "2", "/python/3.8/android/Python-3.8-Android-support.b2.zip"),
 
-    # We've set up all the expected S3 responses, so activate the stub
-    stub_s3.activate()
+        ("iOS", "3.8", None, None, "/python/3.8/iOS/Python-3.8-iOS-support.b9.tar.gz"),
+        ("iOS", "3.10", None, None, "/python/3.10/iOS/Python-3.10-iOS-support.b3.tar.gz"),
+        ("iOS", "3.8", None, "2", "/python/3.8/iOS/Python-3.8-iOS-support.b2.tar.gz"),
 
+        ("macOS", "3.8", None, None, "/python/3.8/macOS/Python-3.8-macOS-support.b9.tar.gz"),
+        ("macOS", "3.10", None, None, "/python/3.10/macOS/Python-3.10-macOS-support.b3.tar.gz"),
+        ("macOS", "3.8", None, "2", "/python/3.8/macOS/Python-3.8-macOS-support.b2.tar.gz"),
+    ]
+)
+def test_valid_support_url(s3, platform, version, host_arch, revision, expected_path):
+    "The support URLs in place at the time of the release of Briefcase v0.3.10 can be returned"
     # Retrieve the property, retrieving the support package URL.
     url = support_url(
         s3,
         bucket='briefcase-support',
-        platform='tester',
-        version='3.X',
-        host_arch=None,
-        revision=None,
+        platform=platform,
+        version=version,
+        host_arch=host_arch,
+        revision=revision,
     )
-
-    # Check the S3 calls have been exhausted
-    stub_s3.assert_no_pending_responses()
 
     # The URL that was returned is as expected.
     parsed_url = urlparse(url)
     assert parsed_url.scheme == 'https'
     assert parsed_url.netloc == 'briefcase-support.s3.amazonaws.com'
-    assert parsed_url.path == '/python/3.X/tester/Python-3.X-tester-support.b1.tar.gz'
+    assert parsed_url.path == expected_path
     query = dict(parse_qsl(parsed_url.query))
     assert 'Expires' in query
     assert 'AWSAccessKeyId' in query
     assert 'Signature' in query
 
 
-def test_single_match_with_arch(s3):
-    "If a single match exists and an arch is provided, it is returned"
-    stub_s3 = Stubber(s3)
 
-    # Add the expected request/responses from S3
-    stub_s3.add_response(
-        method='list_objects_v2',
-        expected_params={
-            'Bucket': 'briefcase-support',
-            'Prefix': 'python/3.X/tester/dummy/'
-        },
-        service_response={
-            'Contents': [
-                {'Key': 'python/3.X/tester/dummy/Python-3.X-tester-dummy-support.b1.tar.gz'}
-            ],
-            'KeyCount': 1,
-        }
-    )
+@pytest.mark.parametrize(
+    "platform, version, host_arch, revision",
+    [
+        # Unknown platform
+        ("something", "3.8", "x86_64", "2"),
+        ("something", "3.8", "x86_64", None),
+        ("something", "3.8", None, "2"),
+        ("something", "3.8", None, None),
 
-    # We've set up all the expected S3 responses, so activate the stub
-    stub_s3.activate()
+        # Linux without a host architecture
+        ("linux", "3.8", None, "2"),
+        ("linux", "3.8", None, None),
 
-    # Retrieve the property, retrieving the support package URL.
-    url = support_url(
-        s3,
-        bucket='briefcase-support',
-        platform='tester',
-        version='3.X',
-        host_arch='dummy',
-        revision=None,
-    )
+        # Linux with a non-x86_64 host architecture
+        ("linux", "3.8", "arm64", "2"),
+        ("linux", "3.8", "arm64", None),
 
-    # Check the S3 calls have been exhausted
-    stub_s3.assert_no_pending_responses()
+        # Non-linux with host architecture
+        ("android", "3.8", "x86_64", "2"),
+        ("android", "3.8", "x86_64", None),
 
-    # The URL that was returned is as expected.
-    parsed_url = urlparse(url)
-    assert parsed_url.scheme == 'https'
-    assert parsed_url.netloc == 'briefcase-support.s3.amazonaws.com'
-    assert parsed_url.path == '/python/3.X/tester/dummy/Python-3.X-tester-dummy-support.b1.tar.gz'
-    query = dict(parse_qsl(parsed_url.query))
-    assert 'Expires' in query
-    assert 'AWSAccessKeyId' in query
-    assert 'Signature' in query
+        ("iOS", "3.8", "x86_64", "2"),
+        ("iOS", "3.8", "x86_64", None),
 
+        ("macOS", "3.8", "x86_64", "2"),
+        ("macOS", "3.8", "x86_64", None),
 
-def test_multiple_match(s3):
-    "If a multiple matches exists, the highest revision is returned"
-    stub_s3 = Stubber(s3)
+        # Unsupported Python versions
+        ("linux", "2.7", "x86_64", None),
+        ("linux", "2.7", "x86_64", "2"),
+        ("linux", "3.4", "x86_64", None),
+        ("linux", "3.4", "x86_64", "2"),
+        ("linux", "3.11", "x86_64", None),
+        ("linux", "3.11", "x86_64", "2"),
 
-    # Add the expected request/responses from S3
-    stub_s3.add_response(
-        method='list_objects_v2',
-        expected_params={
-            'Bucket': 'briefcase-support',
-            'Prefix': 'python/3.X/tester/'
-        },
-        service_response={
-            'Contents': [
-                {'Key': 'python/3.X/tester/Python-3.X-tester-support.b11.tar.gz'},
-                {'Key': 'python/3.X/tester/Python-3.X-tester-support.b8.tar.gz'},
-                {'Key': 'python/3.X/tester/Python-3.X-tester-support.b9.tar.gz'},
-                {'Key': 'python/3.X/tester/Python-3.X-tester-support.b10.tar.gz'},
-            ],
-            'KeyCount': 4,
-        }
-    )
+        ("android", "2.7", None, None),
+        ("android", "2.7", None, "2"),
+        ("android", "3.5", None, None),
+        ("android", "3.5", None, "2"),
+        ("android", "3.11", None, None),
+        ("android", "3.11", None, "2"),
 
-    # We've set up all the expected S3 responses, so activate the stub
-    stub_s3.activate()
+        ("iOS", "2.7", None, None),
+        ("iOS", "2.7", None, "2"),
+        ("iOS", "3.4", None, None),
+        ("iOS", "3.4", None, "2"),
+        ("iOS", "3.11", None, None),
+        ("iOS", "3.11", None, "2"),
 
-    # Retrieve the property, retrieving the support package URL.
-    url = support_url(
-        s3,
-        bucket='briefcase-support',
-        platform='tester',
-        version='3.X',
-        host_arch=None,
-        revision=None,
-    )
+        ("macOS", "2.7", None, None),
+        ("macOS", "2.7", None, "2"),
+        ("macOS", "3.4", None, None),
+        ("macOS", "3.4", None, "2"),
+        ("macOS", "3.11", None, None),
+        ("macOS", "3.11", None, "2"),
 
-    # Check the S3 calls have been exhausted
-    stub_s3.assert_no_pending_responses()
-
-    # The URL that was returned is as expected.
-    parsed_url = urlparse(url)
-    assert parsed_url.scheme == 'https'
-    assert parsed_url.netloc == 'briefcase-support.s3.amazonaws.com'
-    assert parsed_url.path == '/python/3.X/tester/Python-3.X-tester-support.b11.tar.gz'
-    query = dict(parse_qsl(parsed_url.query))
-    assert 'Expires' in query
-    assert 'AWSAccessKeyId' in query
-    assert 'Signature' in query
-
-
-def test_no_match(s3):
-    "If there is no plausible candidate support package, raise an error"
-    stub_s3 = Stubber(s3)
-
-    # Add the expected request/responses from S3
-    stub_s3.add_response(
-        method='list_objects_v2',
-        expected_params={
-            'Bucket': 'briefcase-support',
-            'Prefix': 'python/3.X/tester/'
-        },
-        service_response={
-            'KeyCount': 0,
-        }
-    )
-
-    # We've set up all the expected S3 responses, so activate the stub
-    stub_s3.activate()
-
+    ]
+)
+def test_valid_support_url(s3, platform, version, host_arch, revision):
+    "The support URLs in place at the time of the release of Briefcase v0.3.10 can be returned"
     # Retrieve the property, retrieving the support package URL.
     with pytest.raises(ValueError):
         support_url(
             s3,
             bucket='briefcase-support',
-            platform='tester',
-            version='3.X',
-            host_arch=None,
-            revision=None,
+            platform=platform,
+            version=version,
+            host_arch=host_arch,
+            revision=revision,
         )
-
-    # Check the S3 calls have been exhausted
-    stub_s3.assert_no_pending_responses()
-
-
-def test_revision_match(s3):
-    "If a revision is provided, only an exact match is returned"
-    stub_s3 = Stubber(s3)
-
-    # Add the expected request/responses from S3
-    stub_s3.add_response(
-        method='list_objects_v2',
-        expected_params={
-            'Bucket': 'briefcase-support',
-            'Prefix': 'python/3.X/tester/'
-        },
-        service_response={
-            'Contents': [
-                {'Key': 'python/3.X/tester/Python-3.X-tester-support.b11.tar.gz'},
-                {'Key': 'python/3.X/tester/Python-3.X-tester-support.b8.tar.gz'},
-                {'Key': 'python/3.X/tester/Python-3.X-tester-support.b9.tar.gz'},
-                {'Key': 'python/3.X/tester/Python-3.X-tester-support.b10.tar.gz'},
-            ],
-            'KeyCount': 4,
-        }
-    )
-
-    # We've set up all the expected S3 responses, so activate the stub
-    stub_s3.activate()
-
-    # Retrieve the property, retrieving the support package URL.
-    url = support_url(
-        s3,
-        bucket='briefcase-support',
-        platform='tester',
-        version='3.X',
-        host_arch=None,
-        revision='b8',
-    )
-
-    # Check the S3 calls have been exhausted
-    stub_s3.assert_no_pending_responses()
-
-    # The URL that was returned is as expected.
-    parsed_url = urlparse(url)
-    assert parsed_url.scheme == 'https'
-    assert parsed_url.netloc == 'briefcase-support.s3.amazonaws.com'
-    assert parsed_url.path == '/python/3.X/tester/Python-3.X-tester-support.b8.tar.gz'
-    query = dict(parse_qsl(parsed_url.query))
-    assert 'Expires' in query
-    assert 'AWSAccessKeyId' in query
-    assert 'Signature' in query
-
-
-def test_no_revision_match(s3):
-    "If a revision is provided, but that version doesn't exist, an error is returned"
-    stub_s3 = Stubber(s3)
-
-    # Add the expected request/responses from S3
-    stub_s3.add_response(
-        method='list_objects_v2',
-        expected_params={
-            'Bucket': 'briefcase-support',
-            'Prefix': 'python/3.X/tester/'
-        },
-        service_response={
-            'Contents': [
-                {'Key': 'python/3.X/tester/Python-3.X-tester-support.b11.tar.gz'},
-                {'Key': 'python/3.X/tester/Python-3.X-tester-support.b8.tar.gz'},
-                {'Key': 'python/3.X/tester/Python-3.X-tester-support.b9.tar.gz'},
-                {'Key': 'python/3.X/tester/Python-3.X-tester-support.b10.tar.gz'},
-            ],
-            'KeyCount': 4,
-        }
-    )
-
-    # We've set up all the expected S3 responses, so activate the stub
-    stub_s3.activate()
-
-    # Retrieve the property, retrieving the support package URL.
-
-    # Retrieve the property, retrieving the support package URL.
-    with pytest.raises(ValueError):
-        support_url(
-            s3,
-            bucket='briefcase-support',
-            platform='tester',
-            version='3.X',
-            host_arch=None,
-            revision='b42',
-        )
-
-    # Check the S3 calls have been exhausted
-    stub_s3.assert_no_pending_responses()
-
-
-def test_no_revisions(s3):
-    "If there are no files for the version, and a revision is requested, raise an error"
-    stub_s3 = Stubber(s3)
-
-    # Add the expected request/responses from S3
-    stub_s3.add_response(
-        method='list_objects_v2',
-        expected_params={
-            'Bucket': 'briefcase-support',
-            'Prefix': 'python/3.X/tester/'
-        },
-        service_response={
-            'KeyCount': 0,
-        }
-    )
-
-    # We've set up all the expected S3 responses, so activate the stub
-    stub_s3.activate()
-
-    # Retrieve the property, retrieving the support package URL.
-    with pytest.raises(ValueError):
-        support_url(
-            s3,
-            bucket='briefcase-support',
-            platform='tester',
-            version='3.X',
-            host_arch=None,
-            revision='b8',
-        )
-
-    # Check the S3 calls have been exhausted
-    stub_s3.assert_no_pending_responses()
-
-
-def test_zip_match(s3):
-    "If a match for an zipfile exists, it is returned"
-    stub_s3 = Stubber(s3)
-
-    # Add the expected request/responses from S3
-    stub_s3.add_response(
-        method='list_objects_v2',
-        expected_params={
-            'Bucket': 'briefcase-support',
-            'Prefix': 'python/3.X/ziptest/'
-        },
-        service_response={
-            'Contents': [
-                {'Key': 'python/3.X/ziptest/Python-3.X-ZipTest-support.b1.zip'}
-            ],
-            'KeyCount': 1,
-        }
-    )
-
-    # We've set up all the expected S3 responses, so activate the stub
-    stub_s3.activate()
-
-    # Retrieve the property, retrieving the support package URL.
-    # Android uses .zip format, so the extension is different.
-    url = support_url(
-        s3,
-        bucket='briefcase-support',
-        platform='ziptest',
-        version='3.X',
-        host_arch=None,
-        revision=None,
-    )
-
-    # Check the S3 calls have been exhausted
-    stub_s3.assert_no_pending_responses()
-
-    # The URL that was returned is as expected.
-    parsed_url = urlparse(url)
-    assert parsed_url.scheme == 'https'
-    assert parsed_url.netloc == 'briefcase-support.s3.amazonaws.com'
-    assert parsed_url.path == '/python/3.X/ziptest/Python-3.X-ZipTest-support.b1.zip'
-    query = dict(parse_qsl(parsed_url.query))
-    assert 'Expires' in query
-    assert 'AWSAccessKeyId' in query
-    assert 'Signature' in query

--- a/tests/platforms/test_windows_support_url.py
+++ b/tests/platforms/test_windows_support_url.py
@@ -14,44 +14,16 @@ def test_unsupported_version():
 
 def test_find_version_default_arch(monkeypatch):
     "A windows version can be found with the default architecture"
-    mock_head = mock.MagicMock()
-
-    # Set up responses such that the following versions exsit:
-    # * Python 3.7.5
-    # * Python 3.7.6.post1
-    # * Python 3.7.7 (known bad)
-    # Python 3.7.6.post1 will be the best candidate.
-    mock_head.side_effect = [
-        mock.MagicMock(status_code=200),
-        mock.MagicMock(status_code=404),
-        mock.MagicMock(status_code=200),
-        mock.MagicMock(status_code=404),
-    ]
-    monkeypatch.setattr(requests, 'head', mock_head)
 
     url = windows_support_url(version='3.7', host_arch=None, revision=None)
 
-    # Three URLs were tested
-    mock_head.assert_has_calls([
-        mock.call('https://www.python.org/ftp/python/3.7.5/python-3.7.5-embed-amd64.zip'),
-        mock.call('https://www.python.org/ftp/python/3.7.6/python-3.7.6-embed-amd64.zip'),
-        mock.call('https://www.python.org/ftp/python/3.7.6/python-3.7.6.post1-embed-amd64.zip'),
-        mock.call('https://www.python.org/ftp/python/3.7.7/python-3.7.7.post1-embed-amd64.zip'),
-    ])
-
-    # The second last one is the one returned.
-    assert url == 'https://www.python.org/ftp/python/3.7.6/python-3.7.6.post1-embed-amd64.zip'
+    assert url == 'https://www.python.org/ftp/python/3.7.9/python-3.7.9-embed-amd64.zip'
 
 
 def test_explicit_revision_default_arch(monkeypatch):
     "A specific windows version will be returned if requested"
-    mock_head = mock.MagicMock()
-    monkeypatch.setattr(requests, 'head', mock_head)
 
     url = windows_support_url(version='3.7', host_arch=None, revision='4')
-
-    # No URLs were tested
-    mock_head.assert_not_called()
 
     # The explicit revision is returned
     assert url == 'https://www.python.org/ftp/python/3.7.4/python-3.7.4-embed-amd64.zip'
@@ -64,62 +36,22 @@ def test_explicit_post_revision(monkeypatch):
 
     url = windows_support_url(version='3.7', host_arch=None, revision='4.post1')
 
-    # No URLs were tested
-    mock_head.assert_not_called()
-
     # The explicit revision is returned
     assert url == 'https://www.python.org/ftp/python/3.7.4/python-3.7.4.post1-embed-amd64.zip'
 
 
 def test_find_version_explicit_arch(monkeypatch):
     "A windows version can be found with an explicit architecture"
-    mock_head = mock.MagicMock()
-    # Find the first two candidate micro versions.
-    mock_head.side_effect = [
-        mock.MagicMock(status_code=200),
-        mock.MagicMock(status_code=200),
-        mock.MagicMock(status_code=404),
-    ]
-    monkeypatch.setattr(requests, 'head', mock_head)
 
     url = windows_support_url(version='3.7', host_arch='win32', revision=None)
 
-    # Three URLs were tested
-    mock_head.assert_has_calls([
-        mock.call('https://www.python.org/ftp/python/3.7.5/python-3.7.5-embed-win32.zip'),
-        mock.call('https://www.python.org/ftp/python/3.7.6/python-3.7.6-embed-win32.zip'),
-        mock.call('https://www.python.org/ftp/python/3.7.7/python-3.7.7.post1-embed-win32.zip'),
-    ])
-
-    # The second last one is the one returned.
-    assert url == 'https://www.python.org/ftp/python/3.7.6/python-3.7.6-embed-win32.zip'
+    assert url == 'https://www.python.org/ftp/python/3.7.9/python-3.7.9-embed-win32.zip'
 
 
 def test_explicit_revision_and_arch(monkeypatch):
     "A specific windows version for a given arch will be returned if requested"
-    mock_head = mock.MagicMock()
-    monkeypatch.setattr(requests, 'head', mock_head)
 
     url = windows_support_url(version='3.7', host_arch='win32', revision='4')
 
-    # No URLs were tested
-    mock_head.assert_not_called()
-
     # The explicit revision is returned
     assert url == 'https://www.python.org/ftp/python/3.7.4/python-3.7.4-embed-win32.zip'
-
-
-def test_server_error(monkeypatch):
-    "A windows version can be found with the default architecture"
-    mock_head = mock.MagicMock()
-    # Simulate a python.org failure
-    mock_head.side_effect = mock.MagicMock(status_code=500)
-    monkeypatch.setattr(requests, 'head', mock_head)
-
-    with pytest.raises(RuntimeError):
-        windows_support_url(version='3.7', host_arch=None, revision=None)
-
-    # One URL was tested
-    mock_head.assert_has_calls([
-        mock.call('https://www.python.org/ftp/python/3.7.5/python-3.7.5-embed-amd64.zip'),
-    ])


### PR DESCRIPTION
As part of the switch to Briefcase-versioned templates (Refs beeware/briefcase#862), the support revision used by a template will be locked as part of the template metadata. This makes skep and briefcase-support.org no longer required, as we don't need to dynamically discover the "current" support revision.

For backwards compatibility, we need to preserve briefcase-support.org; however, we need to bake-in the current "best" support packages. This will allow us to publish *new* support packages without them being picked up as options on briefcase-support.org.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
